### PR TITLE
A couple improvements - Improved precision, custom intermediate buffers, custom sampling

### DIFF
--- a/glfft.hpp
+++ b/glfft.hpp
@@ -55,10 +55,19 @@ class FFT
         /// @param options       FFT options such as performance related parameters and types.
         /// @param wisdom        GLFFT wisdom which can override performance related options
         ///                      (options.performance is used as a fallback).
+        /// @param reuse_preallocated_temporary_buffer0
+        ///                      For large FFTs also a large internal temporary buffer is required. To reduce memory consumption
+        ///                      you can provide a preallocated buffer here that can be shared with other parts of the program.
+        ///                      The buffer must have size at least Nx * Ny * (type == ComplexToComplexDual ? 4 : 2) * (options.type.fp16 ? 2 : 4).
+        ///                      The provided buffer must not be used while the FFT is in progress and will contain unpredictable garbage data afterwards.
+        /// @param reuse_preallocated_temporary_buffer1
+        ///                      Same as reuse_preallocated_temporary_buffer0 and used only if the output is a texture.
+        ///                      May be aliased with the input if the input if the input is not needed again after processing.
         FFT(Context *context, unsigned Nx, unsigned Ny,
                 Type type, Direction direction, Target input_target, Target output_target,
                 std::shared_ptr<ProgramCache> cache, const FFTOptions &options,
-                const FFTWisdom &wisdom = FFTWisdom());
+                const FFTWisdom &wisdom = FFTWisdom(), std::unique_ptr<Buffer> reuse_preallocated_temporary_buffer0 = nullptr, 
+                std::unique_ptr<Buffer> reuse_preallocated_temporary_buffer1 = nullptr);
 
         /// @brief Creates a single stage FFT. Used mostly internally for benchmarking partial FFTs.
         ///

--- a/glfft.hpp
+++ b/glfft.hpp
@@ -55,6 +55,10 @@ class FFT
         /// @param options       FFT options such as performance related parameters and types.
         /// @param wisdom        GLFFT wisdom which can override performance related options
         ///                      (options.performance is used as a fallback).
+        /// @param input_load_texture_code
+        ///                      Custom code for sampling the input texture can be inserted here.
+        ///                      This must only use a single line and must define a function with signature 
+        ///                      "cfloat load_texture(uvec2 coord)" and can call "cfloat load_texture_inner(uvec2 coord)".
         /// @param reuse_preallocated_temporary_buffer0
         ///                      For large FFTs also a large internal temporary buffer is required. To reduce memory consumption
         ///                      you can provide a preallocated buffer here that can be shared with other parts of the program.
@@ -66,7 +70,9 @@ class FFT
         FFT(Context *context, unsigned Nx, unsigned Ny,
                 Type type, Direction direction, Target input_target, Target output_target,
                 std::shared_ptr<ProgramCache> cache, const FFTOptions &options,
-                const FFTWisdom &wisdom = FFTWisdom(), std::unique_ptr<Buffer> reuse_preallocated_temporary_buffer0 = nullptr, 
+                const FFTWisdom &wisdom = FFTWisdom(), 
+                std::string input_load_texture_code = input_load_texture_code_default,
+                std::unique_ptr<Buffer> reuse_preallocated_temporary_buffer0 = nullptr,
                 std::unique_ptr<Buffer> reuse_preallocated_temporary_buffer1 = nullptr);
 
         /// @brief Creates a single stage FFT. Used mostly internally for benchmarking partial FFTs.

--- a/glfft.hpp
+++ b/glfft.hpp
@@ -130,12 +130,12 @@ class FFT
         double get_cost() const { return cost; }
 
         /// @brief Returns number of passes (glDispatchCompute) in a process() call.
-        unsigned get_num_passes() const { return passes.size(); }
+        size_t get_num_passes() const { return passes.size(); }
 
         /// @brief Returns Nx.
-        unsigned get_dimension_x() const { return size_x; }
+        size_t get_dimension_x() const { return size_x; }
         /// @brief Returns Ny.
-        unsigned get_dimension_y() const { return size_y; }
+        size_t get_dimension_y() const { return size_y; }
 
         /// @brief Sets offset and scale parameters for normalized texel coordinates when sampling textures.
         ///

--- a/glfft_common.hpp
+++ b/glfft_common.hpp
@@ -33,7 +33,7 @@
 namespace GLFFT
 {
 
-enum Direction
+enum Direction : char
 {
     /// Forward FFT transform.
     Forward = -1,
@@ -44,7 +44,7 @@ enum Direction
     Inverse = 1
 };
 
-enum Mode
+enum Mode : char
 {
     Horizontal,
     HorizontalDual,
@@ -55,7 +55,7 @@ enum Mode
     ResolveComplexToReal,
 };
 
-enum Type
+enum Type : char
 {
     /// Regular complex-to-complex transform.
     ComplexToComplex,
@@ -68,7 +68,7 @@ enum Type
     RealToComplex
 };
 
-enum Target
+enum Target : char
 {
     /// GL_SHADER_STORAGE_BUFFER
     SSBO,
@@ -80,6 +80,11 @@ enum Target
     /// ComplexToReal -> GL_R32F (because GLES 3.1 doesn't have GL_R16F image type).
     ImageReal
 };
+
+static constexpr char const input_load_texture_code_default[] = 
+    "cfloat load_texture(uvec2 coord) {"
+    "    return load_texture_inner(coord);"
+    "}";
 
 struct Parameters
 {
@@ -96,10 +101,11 @@ struct Parameters
     bool shared_banked;
     bool fft_fp16, input_fp16, output_fp16;
     bool fft_normalize;
-
+    std::string input_load_texture_code; // If empty defaults to input_load_texture_code_default. Unfortunately we can't put it here because that breaks the initializer lists in C++11.
     bool operator==(const Parameters &other) const
     {
-        return std::memcmp(this, &other, sizeof(Parameters)) == 0;
+        return std::memcmp(this, &other, offsetof(Parameters, input_load_texture_code)) == 0
+            && input_load_texture_code == other.input_load_texture_code;
     }
 };
 

--- a/glfft_common.hpp
+++ b/glfft_common.hpp
@@ -132,7 +132,7 @@ struct FFTOptions
 
     struct Type
     {
-        /// Whether internal shader should be mediump float.
+        /// Whether internal shader and intermediate results should be mediump float.
         bool fp16 = false;
         /// Whether input SSBO is a packed 2xfp16 format. Otherwise, regular FP32.
         bool input_fp16 = false;

--- a/glfft_wisdom.cpp
+++ b/glfft_wisdom.cpp
@@ -394,7 +394,7 @@ std::pair<double, FFTOptions::Performance> FFTWisdom::study(Context *context, co
                     }
 
                     FFTOptions::Performance perf;
-                    perf.shared_banked = shared_banked;
+                    perf.shared_banked = !!shared_banked;
                     perf.vector_size = vector_size;
                     perf.workgroup_size_x = workgroup_size_x;
                     perf.workgroup_size_y = workgroup_size_y;

--- a/glsl/fft_common.comp
+++ b/glsl/fft_common.comp
@@ -314,7 +314,7 @@ cfloat load_texture(sampler2D sampler, uvec2 coord)
 #endif
 }
 
-cfloat load_texture(uvec2 coord)
+cfloat load_texture_inner(uvec2 coord)
 {
 #ifdef FFT_CONVOLVE
     // Convolution in frequency domain is multiplication.
@@ -325,6 +325,9 @@ cfloat load_texture(uvec2 coord)
     return load_texture(uTexture, coord);
 #endif
 }
+
+// This must define a function with signature cfloat load_texture(uvec2 coord)
+FFT_LOAD_TEXTURE_CODE
 
 // Implement a dummy load_global, or we have to #ifdef out lots of dead code elsewhere.
 #ifdef FFT_VEC8

--- a/test/glfft_cli.cpp
+++ b/test/glfft_cli.cpp
@@ -335,6 +335,7 @@ static int cli_test(Context *context, int argc, char *argv[])
     cbs.add("--minimum-snr-fp32", [&args](CLIParser &parser) { args.min_snr_fp32 = parser.next_double(); });
     cbs.add("--epsilon-fp16",     [&args](CLIParser &parser) { args.epsilon_fp16 = parser.next_double(); });
     cbs.add("--epsilon-fp32",     [&args](CLIParser &parser) { args.epsilon_fp32 = parser.next_double(); });
+    cbs.add("--single-base-size",      [&args](CLIParser &parser) { args.single_base_size = true; });
 
     cbs.error_handler = [context]{ cli_test_help(context); };
     CLIParser parser(move(cbs), argc, argv);

--- a/test/glfft_cli.cpp
+++ b/test/glfft_cli.cpp
@@ -143,7 +143,7 @@ struct BenchArguments
     unsigned warmup = 2;
     unsigned iterations = 20;
     unsigned dispatches = 50;
-    unsigned timeout = 1.0;
+    unsigned timeout = 1;
     Type type = ComplexToComplex;
     unsigned size_for_type = 2;
     const char *string_for_type = "C2C";
@@ -407,7 +407,7 @@ static int cli_bench(Context *context, int argc, char *argv[])
     cbs.add("--warmup",         [&args](CLIParser &parser) { args.warmup = parser.next_uint(); });
     cbs.add("--iterations",     [&args](CLIParser &parser) { args.iterations = parser.next_uint(); });
     cbs.add("--dispatches",     [&args](CLIParser &parser) { args.dispatches = parser.next_uint(); });
-    cbs.add("--timeout",        [&args](CLIParser &parser) { args.timeout = parser.next_double(); });
+    cbs.add("--timeout",        [&args](CLIParser &parser) { args.timeout = (unsigned int)parser.next_double(); });
     cbs.add("--fp16",           [&args](CLIParser&)        { args.fp16 = true; });
     cbs.add("--type",           [&args](CLIParser &parser) { args.type = parse_type(parser.next_string(), args); });
     cbs.add("--input-texture",  [&args](CLIParser&)        { args.input_texture = true; });

--- a/test/glfft_cli.hpp
+++ b/test/glfft_cli.hpp
@@ -40,6 +40,7 @@ namespace GLFFT
             unsigned test_id_min = 0;
             unsigned test_id_max = 0;
             bool exhaustive = true;
+            bool single_base_size = true;
             bool throw_on_fail = false;
             double min_snr_fp16 = 50.0;
             double min_snr_fp32 = 100.0;

--- a/test/glfft_test.cpp
+++ b/test/glfft_test.cpp
@@ -494,11 +494,13 @@ static mufft_buffer convert_fp16_fp32(const uint32_t *input, unsigned N)
 static void run_test_ssbo(Context *context,
         const TestSuiteArguments &args, unsigned Nx, unsigned Ny, Type type, Direction direction, const FFTOptions &options, const shared_ptr<ProgramCache> &cache)
 {
-    context->log("Running SSBO -> SSBO FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s ...\n",
-            Nx, Ny, direction_to_str(direction), type_to_str(type),
-            options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
-            options.type.input_fp16 ? "yes" : "no",
-            options.type.output_fp16 ? "yes" : "no");
+    context->log("Running SSBO -> SSBO FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s\n\tfp16 %s ...\n",
+        Nx, Ny, direction_to_str(direction), type_to_str(type),
+        options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
+        options.type.input_fp16 ? "yes" : "no",
+        options.type.output_fp16 ? "yes" : "no",
+        options.type.fp16 ? "yes" : "no");
+
 
     unique_ptr<Buffer> test_input;
     unique_ptr<Buffer> test_output;
@@ -545,11 +547,12 @@ static void run_test_ssbo(Context *context,
 static void run_test_texture(Context *context,
         const TestSuiteArguments &args, unsigned Nx, unsigned Ny, Type type, Direction direction, const FFTOptions &options, const shared_ptr<ProgramCache> &cache)
 {
-    context->log("Running Texture -> SSBO FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s ...\n",
-            Nx, Ny, direction_to_str(direction), type_to_str(type),
-            options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
-            options.type.input_fp16 ? "yes" : "no",
-            options.type.output_fp16 ? "yes" : "no");
+    context->log("Running Texture -> SSBO FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s\n\tfp16 %s ...\n",
+        Nx, Ny, direction_to_str(direction), type_to_str(type),
+        options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
+        options.type.input_fp16 ? "yes" : "no",
+        options.type.output_fp16 ? "yes" : "no",
+        options.type.fp16 ? "yes" : "no");
 
     unique_ptr<Texture> test_input;
     unique_ptr<Buffer> test_output;
@@ -634,11 +637,12 @@ static mufft_buffer readback_texture(Context *context, Texture *tex, unsigned co
 
 static void run_test_image(Context *context, const TestSuiteArguments &args, unsigned Nx, unsigned Ny, Type type, Direction direction, const FFTOptions &options, const shared_ptr<ProgramCache> &cache)
 {
-    context->log("Running SSBO -> Image FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s ...\n",
-            Nx, Ny, direction_to_str(direction), type_to_str(type),
-            options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
-            options.type.input_fp16 ? "yes" : "no",
-            options.type.output_fp16 ? "yes" : "no");
+    context->log("Running SSBO -> Image FFT, %04u x %04u\n\t%7s transform\n\t%8s\n\tbanked shared %s\n\tvector size %u\n\twork group (%u, %u)\n\tinput fp16 %s\n\toutput fp16 %s\n\tfp16 %s ...\n",
+        Nx, Ny, direction_to_str(direction), type_to_str(type),
+        options.performance.shared_banked ? "yes" : "no", options.performance.vector_size, options.performance.workgroup_size_x, options.performance.workgroup_size_y,
+        options.type.input_fp16 ? "yes" : "no",
+        options.type.output_fp16 ? "yes" : "no", 
+        options.type.fp16 ? "yes" : "no");
 
     unique_ptr<Buffer> test_input;
 
@@ -807,6 +811,11 @@ void GLFFT::Internal::run_test_suite(Context *context, const TestSuiteArguments 
 
         for (unsigned N = N_mult * (big_workgroup ? 128 : 32); N <= 1024; N <<= 1)
         {
+            if (args.single_base_size && N != 256) // Option to make length of test run somewhat reasonable.
+            {
+                continue;
+            }
+
             // Texture -> SSBO
             enqueue_test(context, tests, args, N, N / 2, ComplexToComplex, Forward, Image, SSBO, options, cache);
             enqueue_test(context, tests, args, N, N / 2, ComplexToComplex, Inverse, Image, SSBO, options, cache);

--- a/test/glfft_test.cpp
+++ b/test/glfft_test.cpp
@@ -49,7 +49,7 @@ mufft_buffer alloc(size_t size)
 
 using cfloat = complex<float>;
 
-mufft_buffer create_input(unsigned N)
+mufft_buffer create_input(size_t N)
 {
     auto buffer = alloc(N * sizeof(float));
     float *ptr = static_cast<float*>(buffer.get());
@@ -231,7 +231,7 @@ static mufft_buffer create_reference(Type type, Direction direction,
     out = static_cast<cfloat*>(output.get());
     for (unsigned i = 0; i < output_size / sizeof(cfloat); i++)
     {
-        out[i] /= Nx * Ny;
+        out[i] /= static_cast<float>(Nx * Ny);
     }
 
     return output;
@@ -463,7 +463,7 @@ static inline pair<float, float> fp16_to_fp32(uint32_t v)
     return make_pair(fp16_to_fp32(lower), fp16_to_fp32(upper));
 }
 
-static mufft_buffer convert_fp32_fp16(const float *input, unsigned N)
+static mufft_buffer convert_fp32_fp16(const float *input, size_t N)
 {
     auto buffer = alloc(N * sizeof(uint16_t));
     auto ptr = static_cast<uint32_t*>(buffer.get());
@@ -476,7 +476,7 @@ static mufft_buffer convert_fp32_fp16(const float *input, unsigned N)
     return buffer;
 }
 
-static mufft_buffer convert_fp16_fp32(const uint32_t *input, unsigned N)
+static mufft_buffer convert_fp16_fp32(const uint32_t *input, size_t N)
 {
     auto buffer = alloc(N * sizeof(float));
     auto ptr = static_cast<float*>(buffer.get());
@@ -533,8 +533,8 @@ static void run_test_ssbo(Context *context,
         output_data = convert_fp16_fp32(static_cast<const uint32_t*>(output_data.get()), output_size / sizeof(float));
     }
 
-    float epsilon = options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32;
-    float min_snr = options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32;
+    float epsilon = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32);
+    float min_snr = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32);
     if (direction == InverseConvolve)
     {
         epsilon *= 1.5f;
@@ -600,8 +600,8 @@ static void run_test_texture(Context *context,
         output_data = convert_fp16_fp32(static_cast<const uint32_t*>(output_data.get()), output_size / sizeof(float));
     }
 
-    float epsilon = options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32;
-    float min_snr = options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32;
+    float epsilon = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32);
+    float min_snr = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32);
     if (direction == InverseConvolve)
     {
         epsilon *= 1.5f;
@@ -694,8 +694,8 @@ static void run_test_image(Context *context, const TestSuiteArguments &args, uns
 
     auto output_data = readback_texture(context, tex.get(), components, Nx, Ny);
 
-    float epsilon = components > 1 || options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32;
-    float min_snr = components > 1 || options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32;
+    float epsilon = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.epsilon_fp16 : args.epsilon_fp32);
+    float min_snr = static_cast<float>(options.type.output_fp16 || options.type.input_fp16 ? args.min_snr_fp16 : args.min_snr_fp32);
     if (direction == InverseConvolve)
     {
         epsilon *= 1.5f;


### PR DESCRIPTION
I don't know if this project is still maintained, but I want to contribute my changes back.

My changes are grouped into multiple commits.I thought about doing multiple PRs but that seemed more complicated so I decided to group everything here instead. The changes are basically:
- An option was added to allow using external OpenGL buffers for the intermediate results. These can be quite significant in size for larger FFTs. For example let's say you want do a classical convolution containing both a forward and a backward FFT. If both allocate their own internal storage, up to two additional internal buffers may be allocated, amounting in our case to 512 MB (= 2 Buffers * 4096² Pixel/Buffer * 16 Bytes/Pixel)!
- An option was added to allow inserting custom sampling code. For post processing applications this allows doing some simple calculations like prefiltering and color space transformations directly without introducing another memory roundtrip.
- Sometimes half precision floating points were internally used in the case that the output format was only half precision. This is not generally a safe assumption. For example again in the classical case of a convolution filter, you may have an input image with high dynamic range but limited precision such that half precision suffices for it nicely. However the frequency space _and during the FFT_, very dim and very bright regions are summed which causes precision loss in the dimer regions due to the nature of floats. Because of this the intermediate results cannot really be 16 bit in that case. Whether half precision intermediate buffers are used is controlled by the preexisting `fp16` option.
- Minor changes: Fixed a couple type conversion warnings and added command option to run fewer tests.

I am happy to make adjustments if you have any concerns regarding the changes. I ran the shortend version of the test program.